### PR TITLE
Displaying the present Lastcontribution enum value

### DIFF
--- a/src/Contribute.js
+++ b/src/Contribute.js
@@ -18,9 +18,7 @@ export default function Main (props) {
     setFormState(prev => ({ ...prev, [data.state]: data.value }));
     if (data.value === '' || data.value <= 0) {
       setDisableButton(true);
-    } else {
-      setDisableButton(false);
-    }
+    } else { setDisableButton(false); }
   };
 
   const bestNumber = api.derive.chain.bestNumber;

--- a/src/Crowdloan.js
+++ b/src/Crowdloan.js
@@ -35,29 +35,29 @@ export default function Main (props) {
   }
 
   return (
-        <div>
-            <h1>Crowdloan Funds</h1>
-            {loading
-              ? (
-                    <div>loading...</div>
-                )
-              : (
-                    <div>
-                        {/* dynamic rendering of key, value pair of json: needs to be flattened! */}
-                        {/* {Object.keys(crowdLoan).map((key, i) => (
+    <div>
+      <h1>Crowdloan Funds</h1>
+      {loading
+        ? (
+          <div>loading...</div>
+          )
+        : (
+          <div>
+            {/* dynamic rendering of key, value pair of json: needs to be flattened! */}
+            {/* {Object.keys(crowdLoan).map((key, i) => (
                             <p key={i}>
                                 <span>{key}: </span>
                                 <span>{crowdLoan[key]}</span>
                             </p>
                         ))} */}
-                        <div>raised: {(crowdLoan.raised)}</div>
-                        <div>end: {crowdLoan.end}</div>
-                        <div>cap: {(crowdLoan.cap)}</div>
-                        <div>last_contribution.preEnding: {crowdLoan.lastContribution.PreEnding}</div>
-                        <div>first_period: {crowdLoan.firstPeriod}</div>
-                        <div>last_period: {crowdLoan.lastPeriod}</div>
-                    </div>
-                )}
-        </div >
+            <div>raised: {(crowdLoan.raised)}</div>
+            <div>end: {crowdLoan.end}</div>
+            <div>cap: {(crowdLoan.cap)}</div>
+            <div>last_contribution.Ending: {crowdLoan.lastContribution.Ending}</div>
+            <div>first_period: {crowdLoan.firstPeriod}</div>
+            <div>last_period: {crowdLoan.lastPeriod}</div>
+          </div>
+          )}
+    </div >
   );
 }

--- a/src/Crowdloan.js
+++ b/src/Crowdloan.js
@@ -10,7 +10,7 @@ export default function Main (props) {
     // raised: null,
     // end: null,
     // cap: null,
-    // lastContribution: { preEnding: null },
+    // lastContribution: { preEnding: null, Ending: null, Never: null},
     // firstPeriod: null,
     // lastPeriod: null,
   });
@@ -53,7 +53,9 @@ export default function Main (props) {
             <div>raised: {(crowdLoan.raised)}</div>
             <div>end: {crowdLoan.end}</div>
             <div>cap: {(crowdLoan.cap)}</div>
-            <div>last_contribution.Ending: {crowdLoan.lastContribution.Ending}</div>
+            {crowdLoan.lastContribution.Ending ? (<div>last_contribution.Ending: {crowdLoan.lastContribution.Ending}</div>):null}
+            {crowdLoan.lastContribution.PreEnding ? (<div>last_contribution.PreEnding: {crowdLoan.lastContribution.PreEnding}</div>):null}
+            {crowdLoan.lastContribution.Never ? (<div>last_contribution.Never: {crowdLoan.lastContribution.Never}</div>):null}
             <div>first_period: {crowdLoan.firstPeriod}</div>
             <div>last_period: {crowdLoan.lastPeriod}</div>
           </div>

--- a/src/Crowdloan.js
+++ b/src/Crowdloan.js
@@ -53,9 +53,9 @@ export default function Main (props) {
             <div>raised: {(crowdLoan.raised)}</div>
             <div>end: {crowdLoan.end}</div>
             <div>cap: {(crowdLoan.cap)}</div>
-            {crowdLoan.lastContribution.Ending ? (<div>last_contribution.Ending: {crowdLoan.lastContribution.Ending}</div>):null}
-            {crowdLoan.lastContribution.PreEnding ? (<div>last_contribution.PreEnding: {crowdLoan.lastContribution.PreEnding}</div>):null}
-            {crowdLoan.lastContribution.Never ? (<div>last_contribution.Never: {crowdLoan.lastContribution.Never}</div>):null}
+            {crowdLoan.lastContribution.Ending ? (<div>last_contribution.Ending: {crowdLoan.lastContribution.Ending}</div>) : null}
+            {crowdLoan.lastContribution.PreEnding ? (<div>last_contribution.PreEnding: {crowdLoan.lastContribution.PreEnding}</div>) : null}
+            {crowdLoan.lastContribution.Never ? (<div>last_contribution.Never: {crowdLoan.lastContribution.Never}</div>) : null}
             <div>first_period: {crowdLoan.firstPeriod}</div>
             <div>last_period: {crowdLoan.lastPeriod}</div>
           </div>


### PR DESCRIPTION
Now all possible enum values of LastContribution according to: https://github.com/paritytech/polkadot/blob/master/runtime/common/src/crowdloan.rs
are covered.

The one that is not null will be displayed.

tested on paraId 2004 (Ending)
tested on paraId 2006 (PreEnding)
didn't find a paraId with value 'Never'