### PR TITLE
fix ss58format for backend and email

### DIFF
--- a/src/Participate.js
+++ b/src/Participate.js
@@ -58,6 +58,7 @@ export default function Participate(props) {
   }, [bestNumber]);
 
   const { apiState, keyring, keyringState, apiError } = useSubstrate();
+  keyring.setSS58Format(2);
   const accountPair =
     accountAddress &&
     keyringState === 'READY' &&


### PR DESCRIPTION
Currently, the generic account address (starting with "5...") is sent to the api and therefore stored in the db and sent in the confirmation email. this may confuse users

So we specifically set the prefix to 2 for Kusama