### PR TITLE
show transferable amount of tokens instead of total amount 

### DIFF
--- a/src/AccountSelector.js
+++ b/src/AccountSelector.js
@@ -134,7 +134,7 @@ function BalanceAnnotation (props) {
     accountSelected &&
       api.query.system
         .account(accountSelected, (balance) => {
-          setAccountBalance(balance.data.free.toJSON());
+          setAccountBalance(balance.data.free - balance.data.miscFrozen);
         })
         .then((unsub) => {
           unsubscribe = unsub;


### PR DESCRIPTION
closes #52 
closes #53 
Display transferable amount instead of "free" amount, which was not considering the locked tokens.
balance.data.free - balance.data.miscFrozen contains all transfarable tokens (as far as I understood, please check/verify).
Next step would be to talk the fees also into the calculation or at least display them.