### PR TITLE
fix fee estimation

### DIFF
--- a/src/Participate.js
+++ b/src/Participate.js
@@ -122,7 +122,7 @@ export default function Participate (props) {
     if (!crowdLoanEnded) {
       if (data.value >= 0.1) {
         try {
-          const txExcecuteDummy = api.tx.crowdloan.contribute(paraId, data.value * Math.pow(10, 12), null);
+          const txExcecuteDummy = api.tx.crowdloan.contribute(paraId, Math.pow(10, 12), null);
           const info = await txExcecuteDummy.paymentInfo(accountAddress);
           setEstimatedFee(() => info.partialFee.toHuman());
         } catch (error) {


### PR DESCRIPTION
@anizeani this should fix your concern for value overflow when estimating extrinsic fees. But actually, I think we should not do math.pow but use js/api functions to respect decimals. This will fail for polkadot later on as the decimals are 10^10, not 10^12 for DOT 